### PR TITLE
Improving response time and database load

### DIFF
--- a/grails-app/controllers/unapp/TeacherController.groovy
+++ b/grails-app/controllers/unapp/TeacherController.groovy
@@ -385,14 +385,13 @@ class TeacherController {
     }
 
     def search_by_keywords(String keyWordsAsString) {
-        def keyWords = keyWordsAsString.split(" ")
-        def teachers = [].toSet()
-        keyWords.each { keyWord ->
-            if (teachers.isEmpty())
-                teachers.addAll(Teacher.findAllByNameIlike("%" + keyWord + "%"))
-            else
-                teachers = teachers.intersect(Teacher.findAllByNameIlike("%" + keyWord + "%"))
+        def keyWords = keyWordsAsString.toLowerCase().split(" ")
+        def teachers = Teacher.findAllByNameIlike("%" + keyWords.first() + "%")
+        teachers.findAll { teacher ->
+            def nameToLower = teacher.name.toLowerCase()
+            keyWords.every { keyword ->
+                nameToLower.contains(keyword)
+            }
         }
-        teachers.toSet()
     }
 }


### PR DESCRIPTION
In un-app, older queries arrived after new queries so they're being rewritten with old data, a possible solution is to reduce the response time in the search endpoint.

Fixes:
-Lower the amount of database queries
-Instead of intersecting N sets, it filters the users whose names contain every keyword.